### PR TITLE
Update calculus-derivatives-with-python.ipynb

### DIFF
--- a/calculus-derivatives-with-python.ipynb
+++ b/calculus-derivatives-with-python.ipynb
@@ -253,7 +253,7 @@
             "cell_type": "markdown",
             "metadata": {},
             "source": [
-                "## A function a its derivative"
+                "## A function and its derivative"
             ]
         },
         {


### PR DESCRIPTION
Missing preposition "and" in title in line 256