### PR TITLE
Update finding-patterns-in-data.es.ipynb

### DIFF
--- a/finding-patterns-in-data.es.ipynb
+++ b/finding-patterns-in-data.es.ipynb
@@ -184,7 +184,7 @@
    "source": [
     "## Diferentes patrones, diferentes funciones\n",
     "\n",
-    "Los patrones de datos pueden describirse con funciones algebraicas y puedes trazarlas y visualizarlas en gráficos. Tienes que familiarizarte con las funciones elementales usuales para poder identificar rápidamente el patrón mas parecido en los datos.\n",
+    "Los patrones de datos pueden describirse con funciones algebraicas y puedes trazarlas y visualizarlas en gráficos. Tienes que familiarizarte con las funciones elementales usuales para poder identificar rápidamente el patrón más parecido en los datos.\n",
     "\n"
    ]
   }


### PR DESCRIPTION
En este caso se está utilizando la palabra "mas" como una característica del objeto (patrón), por lo tanto se tilda. Según la RAE, el adverbio "más" se emplea normalmente ante adjetivos en grado positivo que denotan propiedades graduables, en este caso "patrón más parecido".