### PR TITLE
Update calculus-derivatives-with-python.ipynb

### DIFF
--- a/calculus-derivatives-with-python.ipynb
+++ b/calculus-derivatives-with-python.ipynb
@@ -258,6 +258,27 @@
         },
         {
             "cell_type": "code",
+            "execution_count": 18,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "def f(x):\n",
+                "    return (2*x+8.6)*(x+2.2)*(x)*(2*x-3)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 18,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "df(x):\n",
+                "    h = 0.000001\n"
+                "    return (f(x + h) - f(x))/h"
+            ]
+        },
+        {
+            "cell_type": "code",
             "execution_count": 8,
             "metadata": {},
             "outputs": [


### PR DESCRIPTION
Update of the function because when running the notebook the graph of the function does not show the function of the lesson.