### PR TITLE
Tarea corrección error ortográfico probability-bernoulli-with-python.…

### DIFF
--- a/probability-bernoulli-with-python.es.ipynb
+++ b/probability-bernoulli-with-python.es.ipynb
@@ -132,7 +132,7 @@
         "id": "THV-KaywAGuf"
       },
       "source": [
-        "Que es igual a 0.6. De forma similar, la probabilidad de sello ($k = 0$): \n",
+        "Que es igual a 0.6. De forma similar, la probabilidad de sello ($k = 1$): \n",
         "\n",
         "$$f(1, .4) = .4 * 1 + (1 - 1)(1 - 1)$$\n",
         "\n",


### PR DESCRIPTION
…es.ipynb

Al momento de calcular la probability mass function para el caso de SELLO, el enunciado dice: "la probabilidad de sello K=0", eso no es correcto.

En la fórmula para calcular la probabilidad de sello se usa K=1, por lo que lo que dice el enunciado de usar K=0 no está bien, además K=0 está para calcular la probabilidad de cara.

El cambio realizado es, antes de la fórmula de probabilidad de sello, cambiar "K=0" a "K=1"